### PR TITLE
update gha run schedule and pattern

### DIFF
--- a/.github/workflows/run-cypress-sample1.yml
+++ b/.github/workflows/run-cypress-sample1.yml
@@ -3,12 +3,9 @@ name: Cypress Tests with Slack Notification
 run-name: "Cypress run for sample1 test on ${{ github.ref }} by ${{ github.actor }}"
 
 on:
-  # push:
-  #   branches: [ main ]
-  # pull_request:
-  #   branches: [ main ]
+  push:
   schedule:
-    # This cron will never run (Feb 30th does not exist)
+    #This cron will never run (Feb 30th does not exist)
     - cron: '0 0 30 2 *'
 
 jobs:

--- a/.github/workflows/run-cypress-sample2.yml
+++ b/.github/workflows/run-cypress-sample2.yml
@@ -2,16 +2,12 @@ name: Cypress Tests with Slack Notification
 
 run-name: "Cypress run for Sample2 test on ${{ github.ref }} by ${{ github.actor }}"
 
-
-
 on:
-  # push:
-  #   branches: [ main ]
-  # pull_request:
-  #   branches: [ main ]
+  push:
   schedule:
-    # This cron will never run (Feb 30th does not exist)
+    #This cron will never run (Feb 30th does not exist)
     - cron: '0 0 30 2 *'
+
 jobs:
   sample2-run:
     runs-on: ubuntu-latest


### PR DESCRIPTION

This pull request updates the GitHub Actions workflows for Cypress tests to enable them to run on every push event, rather than being commented out. The scheduled run remains unchanged and intentionally set to never trigger.

**Workflow trigger updates:**

* Enabled the `push` trigger for the Cypress test workflows in `.github/workflows/run-cypress-sample1.yml` and `.github/workflows/run-cypress-sample2.yml`, so tests now run on every push. 


* The scheduled cron job remains set to an impossible date (Feb 30th), ensuring it never runs. 