### PR TITLE
updating GHA scheduler

### DIFF
--- a/.github/workflows/run-cypress-sample1.yml
+++ b/.github/workflows/run-cypress-sample1.yml
@@ -4,6 +4,8 @@ run-name: "Cypress run for sample1 test on ${{ github.ref }} by ${{ github.actor
 
 on:
   push:
+    branches:
+      - main
   schedule:
     #This cron will never run (Feb 30th does not exist)
     - cron: '0 0 30 2 *'

--- a/.github/workflows/run-cypress-sample2.yml
+++ b/.github/workflows/run-cypress-sample2.yml
@@ -4,6 +4,8 @@ run-name: "Cypress run for Sample2 test on ${{ github.ref }} by ${{ github.actor
 
 on:
   push:
+    branches:
+      - main
   schedule:
     #This cron will never run (Feb 30th does not exist)
     - cron: '0 0 30 2 *'

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,17 @@ cypress/reports/
 # Misc
 .DS_Store
 .env
+
+# Editor temp files
+~*
+*~
+*.swp
+
+# Coverage directory
+coverage
+
+# IntelliJ IDEA
+/.idea/
+
+# nyc test coverage tool output
+.nyc_output/


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for Cypress tests, ensuring that the workflows only run on pushes to the `main` branch. This helps prevent unnecessary workflow runs on other branches.

Workflow configuration updates:

* Restricted the `push` trigger to only run on the `main` branch in `.github/workflows/run-cypress-sample1.yml`.
* Restricted the `push` trigger to only run on the `main` branch in `.github/workflows/run-cypress-sample2.yml`.